### PR TITLE
Add CUDA provider support via Dockerfile and docker-compose config

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+ENV PYTHONPATH=/app
+WORKDIR /app/src
+
+# Download required model files
+RUN mkdir -p /app/src
+ADD --checksum=sha256:7d5df8ecf7d4b1878015a32686053fd0eebe2bc377234608764cc0ef3636a6c5 https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx /app/src/kokoro-v1.0.onnx
+ADD --checksum=sha256:bca610b8308e8d99f32e6fe4197e7ec01679264efed0cac9140fe9c29f1fbf7d https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin /app/src/voices-v1.0.bin
+
+# Install shared dependencies first, then force the CUDA-only ONNX Runtime stack.
+COPY requirements-cuda.txt .
+RUN pip install -r requirements-cuda.txt
+RUN pip install "onnxruntime-gpu[cuda,cudnn]==1.24.4"
+RUN pip install --no-deps "kokoro-onnx==0.4.5"
+
+COPY src/ /app/src/
+
+ENTRYPOINT ["/usr/local/bin/python3", "main.py"]

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    image: ghcr.io/relvacode/kokoro-wyoming:cuda
+    build:
+      context: .
+      dockerfile: Dockerfile.cuda
+    ports:
+      - "10210:10210"
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      ONNX_PROVIDER: CUDAExecutionProvider
+      LD_LIBRARY_PATH: /usr/local/lib/python3.12/site-packages/nvidia/cublas/lib:/usr/local/lib/python3.12/site-packages/nvidia/cuda_nvrtc/lib:/usr/local/lib/python3.12/site-packages/nvidia/cuda_runtime/lib:/usr/local/lib/python3.12/site-packages/nvidia/cudnn/lib:/usr/local/lib/python3.12/site-packages/nvidia/cufft/lib:/usr/local/lib/python3.12/site-packages/nvidia/curand/lib:/usr/local/lib/python3.12/site-packages/nvidia/nvjitlink/lib
+    gpus: all
+    restart: unless-stopped

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,5 @@
+wyoming==1.6.0
+numpy>=2.0.2
+colorlog>=6.9.0
+espeakng-loader>=0.2.4
+phonemizer-fork==3.3.1


### PR DESCRIPTION
Adds a separate Dockerfile.cuda with onnxruntime-gpu[cuda,cudnn] for GPU-accelerated inference, plus a matching docker-compose.cuda.yml that mounts NVIDIA GPUs.

let me know if you want changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA-enabled Docker container configuration with Python 3.12
  * Automatically downloads and installs required model artifacts during image build
  * New Docker Compose service configuration with GPU device support, auto-restart, and API access on port 10210

<!-- end of auto-generated comment: release notes by coderabbit.ai -->