### PR TITLE
fix: upgrade `onnxruntime-openvino` 1.20.0 → 1.23.0

### DIFF
--- a/requirements-openvino.txt
+++ b/requirements-openvino.txt
@@ -1,1 +1,1 @@
-onnxruntime-openvino==1.20.0
+onnxruntime-openvino==1.23.0


### PR DESCRIPTION
Fix <https://github.com/microsoft/onnxruntime/issues/24911> as present in the current image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenVINO runtime dependency to version 1.23.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->